### PR TITLE
map example uses 4.x to load a web map

### DIFF
--- a/addon/services/esri-loader.js
+++ b/addon/services/esri-loader.js
@@ -11,7 +11,7 @@ export default Ember.Service.extend({
 
   // inject a script tag pointing to the JSAPI in the page
   // and return a promise once it's loaded
-  load (options) {
+  load (options = {}) {
     // if already loading or loaded, return the existing promise
     if (this._loadPromise) {
       return this._loadPromise;

--- a/tests/dummy/app/components/esri-map.js
+++ b/tests/dummy/app/components/esri-map.js
@@ -10,24 +10,26 @@ export default Ember.Component.extend({
   didInsertElement () {
     this._super(...arguments);
     // load the map modules
-    this.get('esriLoader').loadModules(['esri/map', 'esri/layers/VectorTileLayer']).then(modules => {
-      const [Map, VectorTileLayer] = modules;
-      // create a map at the DOM node
-      this._map = new Map(this.elementId, {
-        center: [2.3508, 48.8567], // longitude, latitude
-        zoom: 11
+    this.get('esriLoader').loadModules(['esri/views/MapView', 'esri/WebMap']).then(modules => {
+      const [MapView, WebMap] = modules;
+      // load the webmap from a portal item
+      const webmap = new WebMap({
+        portalItem: { // autocasts as new PortalItem()
+          id: "f2e9b762544945f390ca4ac3671cfa72"
+        }
       });
-      // add a layer
-      var vtlayer = new VectorTileLayer('https://www.arcgis.com/sharing/rest/content/items/bf79e422e9454565ae0cbe9553cf6471/resources/styles/root.json');
-      this._map.addLayer(vtlayer);
+      // Set the WebMap instance to the map property in a MapView.
+      this._view = new MapView({
+        map: webmap,
+        container: this.elementId
+      });
     });
   },
 
   // destroy the map before this component is removed from the DOM
   willDestroyElement () {
-    if (this._map) {
-      this._map.destroy();
-      delete this._map;
+    if (this._view) {
+      delete this._view;
     }
   }
 });

--- a/tests/dummy/app/controllers/map.js
+++ b/tests/dummy/app/controllers/map.js
@@ -10,8 +10,8 @@ export default Ember.Controller.extend({
     // set a property to show the loaded state of the JSAPI
     const esriLoader = this.get('esriLoader');
     this.set('jsapiLoaded', esriLoader.isLoaded());
-    // lazy load the JSAPI
-    esriLoader.load({ url: 'https://js.arcgis.com/3.20' }).then(() => {
+    // lazy load the latest (4.x) version of the JSAPI
+    esriLoader.load().then(() => {
       this.set('jsapiLoaded', esriLoader.isLoaded());
     }, err => {
       // TODO: better way of showing error

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -2,7 +2,7 @@
 @import url('https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css');
 
 /* esri styles */
-@import url('https://js.arcgis.com/3.20/esri/css/esri.css');
+@import url('https://js.arcgis.com/4.3/esri/css/main.css');
 
 /* app styles */
 body {
@@ -12,4 +12,9 @@ body {
 
 .navbar {
   margin-bottom: 20px;
+}
+
+.esri-view {
+  height: 400px;
+  width: 100%;
 }


### PR DESCRIPTION
Switching over to use 4x in the dummy app. Originally wanted to have dummy app show both, but I think 4x w/ README showing 3x instructions is fine for now.

Fixes a bug where you could not pass an empty options to `.load()`.

If this looks good, I'll add a /scene route that loads a web scene too.
 

