### PR TITLE
Use esri loader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "4"
+  - "6"
 
 sudo: false
 

--- a/addon/services/esri-loader.js
+++ b/addon/services/esri-loader.js
@@ -10,6 +10,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
+/* global esriLoader: false */
 import Ember from 'ember';
 
 export default Ember.Service.extend({
@@ -17,7 +18,7 @@ export default Ember.Service.extend({
   // emulate computed property isLoaded to indicate that the JSAPI been loaded
   unknownProperty (key) {
     if (key === 'isLoaded') {
-      return !!window.__dojoRequire;
+      return esriLoader.isLoaded();
     }
   },
 
@@ -28,34 +29,19 @@ export default Ember.Service.extend({
     if (this._loadPromise) {
       return this._loadPromise;
     }
-    // if loaded by other means (i.e. pre-existing script tag on the page)
-    if (this.get('isLoaded')) {
-      // TODO: check if same version of the JSAPI, then resolve like
-      // this._loadPromise = Ember.RSVP.resolve({ previouslyLoaded: true });
-      // return this._loadPromise;
-      // otherwise reject w/ error saying that a different version has been loaded
-      return Ember.RSVP.reject(new Error('The ArcGIS API for JavaScript is already loaded.'));
-    }
     // otherwise create a promise that will resolve when the JSAPI is loaded
     this._loadPromise = new Ember.RSVP.Promise((resolve, reject) => {
-      // create a script object whose source points to the API
-      const script = document.createElement('script');
-      script.type = 'text/javascript';
-      script.src = options.url || 'https://js.arcgis.com/4.3';
-      // once the script is loaded...
-      script.onload = () => {
-        // notify any watchers of isLoaded copmuted property
-        this.notifyPropertyChange('isLoaded');
-        // let the caller know that the API has been successfully loaded
-        // TODO: would there be something more useful to return here?
-        resolve({ success: true });
-      };
-      // reject on script error
-      script.onerror = () => {
-        reject(new Error(`Error while attempting to load ${script.src}`));
-      };
-      // load the script
-      document.body.appendChild(script);
+      esriLoader.bootstrap(err => {
+        if (err) {
+          reject(err);
+        } else {
+          // notify any watchers of isLoaded copmuted property
+          this.notifyPropertyChange('isLoaded');
+          // let the caller know that the API has been successfully loaded
+          // TODO: would there be something more useful to return here?
+          resolve({ success: true });
+        }
+      }, options);
     });
     return this._loadPromise;
   },
@@ -64,6 +50,7 @@ export default Ember.Service.extend({
   loadModules (moduleNames) {
     // TODO: validate that moduleNames is an array w/ at least one string?
     // or just continue to let dojo throw "Cannot read property 'has' of undefined"?
+    // TODO: we can probably delegate some or all of this logic to esriLoader.dojoRequire
     if (this.get('isLoaded')) {
       return this._loadModules(moduleNames);
     } else {
@@ -77,11 +64,10 @@ export default Ember.Service.extend({
     }
   },
 
-  // require the modules and return a pomise that reolves them as an array
+  // wrap esriLoader's dojoRequire in a promise
   _loadModules (moduleNames) {
     return new Ember.RSVP.Promise(resolve => {
-      // NOTE: this function name will be replaced at build time
-      window.__dojoRequire(moduleNames, (...modules) => {
+      esriLoader.dojoRequire(moduleNames, (...modules) => {
         resolve(modules);
       });
     });

--- a/addon/services/esri-loader.js
+++ b/addon/services/esri-loader.js
@@ -10,8 +10,8 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-/* global esriLoader: false */
 import Ember from 'ember';
+import esriLoader from 'esri-loader';
 
 export default Ember.Service.extend({
 

--- a/index.js
+++ b/index.js
@@ -50,10 +50,9 @@ module.exports = {
   // inject esri-loader script tag instead of importing into vendor.js
   // so that it is not subject to the find and replace below
   contentFor (type, config) {
-    var isProduction = config.environment === 'production';
-    var fileName = isProduction ? 'esri-loader.min.js' : 'esri-loader.js';
-    // TODO: or test-body-footer?
-    if (type === 'body-footer') {
+    if (type === 'body-footer' || type === 'test-body-footer') {
+      var isProduction = config.environment === 'production';
+      var fileName = isProduction ? 'esri-loader.min.js' : 'esri-loader.js';
       return '<script src="' + config.rootURL + 'assets/' + fileName + '"></script>';
     }
   },
@@ -81,14 +80,6 @@ module.exports = {
       }, {
         match: /(\W|^|["])require(\W|["]|$)/g,
         replacement: '$1equireray$2'
-      }, {
-        // TODO: remove this once we have tests configured to spy on esriLoader
-        // TODO: probably a better way to achieve this, but for now
-        // we use a special token "__dojoRequire" for the places in the
-        // esri-loader service where we want to allow nested require statements
-        // and this regExp will replace that token with calls to require()
-        match: /(\W|^|["])__dojoRequire(\W|["]|$)/g,
-        replacement: '$1require$2'
       }]
     };
     var dataTree = stringReplace(tree, data);

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@
 var path = require('path');
 var Funnel = require('broccoli-funnel');
 var MergeTrees = require('broccoli-merge-trees');
+var uglify = require('broccoli-uglify-sourcemap');
 var stringReplace = require('broccoli-string-replace');
 
 module.exports = {
@@ -30,10 +31,14 @@ module.exports = {
   // copy UMD build of esri-loader to public tree
   // as a peer to vendor and app scripts
   treeForPublic(publicTree) {
+    var env = this.app.env;
     var esriLoaderTree = new Funnel(path.dirname(require.resolve('esri-loader/esri-loader.js')), {
       files: ['esri-loader.js'],
       destDir: 'assets'
     });
+    if (env === 'production') {
+      esriLoaderTree = uglify(esriLoaderTree);
+    }
     if (!publicTree) {
       return esriLoaderTree;
     }

--- a/index.js
+++ b/index.js
@@ -21,6 +21,12 @@ var stringReplace = require('broccoli-string-replace');
 module.exports = {
   name: 'ember-esri-loader',
 
+  // support "import esriLoader from 'esri-loader';" syntax
+  included() {
+    this._super.included.apply(this, arguments);
+    this.import('vendor/shims/esri-loader.js');
+  },
+
   // copy UMD build of esri-loader to public tree
   // as a peer to vendor and app scripts
   treeForPublic(publicTree) {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,11 @@
     "test": "ember try:each"
   },
   "dependencies": {
+    "broccoli-funnel": "^1.1.0",
+    "broccoli-merge-trees": "^2.0.0",
     "broccoli-string-replace": "^0.1.2",
-    "ember-cli-babel": "^5.1.7"
+    "ember-cli-babel": "^5.1.7",
+    "esri-loader": "^0.3.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,8 @@
     "broccoli-funnel": "^1.1.0",
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-string-replace": "^0.1.2",
-    "broccoli-uglify-sourcemap": "^1.5.2",
     "ember-cli-babel": "^5.1.7",
-    "esri-loader": "^0.3.0"
+    "esri-loader": "^0.3.1"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "broccoli-funnel": "^1.1.0",
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-string-replace": "^0.1.2",
+    "broccoli-uglify-sourcemap": "^1.5.2",
     "ember-cli-babel": "^5.1.7",
     "esri-loader": "^0.3.0"
   },

--- a/tests/unit/services/esri-loader-test.js
+++ b/tests/unit/services/esri-loader-test.js
@@ -26,10 +26,7 @@ test('when has not yet been loaded', function(assert) {
   });
 });
 
-// NOTE: hoping to be able to use esri-loader library, see:
-// https://github.com/ArcGIS/ember-esri-loader/issues/13
-// in which case most of the tests below should be covered in that repo
-
+// TODO: move the logic of tests to the esri-loader library
 test('load', function(assert) {
   const done = assert.async();
   assert.expect(2);
@@ -39,7 +36,7 @@ test('load', function(assert) {
   });
   service.load();
   assert.ok(stub.calledOnce, 'appendChild was called once');
-  assert.equal(stub.getCall(0).args[0].src, 'https://js.arcgis.com/4.3');
+  assert.equal(stub.getCall(0).args[0].src, 'https://js.arcgis.com/4.3/');
   done();
 });
 

--- a/tests/unit/services/esri-loader-test.js
+++ b/tests/unit/services/esri-loader-test.js
@@ -1,69 +1,74 @@
 import { moduleFor } from 'ember-qunit';
 import test from 'ember-sinon-qunit/test-support/test';
+import esriLoader from 'esri-loader';
 
 moduleFor('service:esri-loader', 'Unit | Service | esri loader', {
   // Specify the other units that are required for this test.
   // needs: ['service:foo']
-  beforeEach () {
-    // remove previously stubbed require function
-    // NOTE: this could cause problems if used w/ other tests
-    // that actually call laod() w/o stubbing the function (i.e. acceptance tests)
-    // but it prevents the "not yet loaded" test from causing failures
-    delete window.__dojoRequire;
-  }
 });
 
-// that can be mutated outside of this test, like in an acceptance test
-test('when has not yet been loaded', function(assert) {
-  assert.expect(2);
+test('isLoaded', function (assert) {
   let service = this.subject();
-  // NOTE: this could fail if used w/ other tests that actually call laod()
-  assert.notOk(service.get('isLoaded'), 'isLoaded should be false');
-  // try loading modules before JSAPI is loaded - this should fail
-  // NOTE: if actually loaded this can cause tests to hang
-  return service.loadModules(['esri/map', 'esri/layers/VectorTileLayer']).then(() => {}, err => {
-    assert.equal(err.message, 'The ArcGIS API for JavaScript has not been loaded. You must first call esriLoader.load()');
+  const stub = this.stub(esriLoader, 'isLoaded');
+  service.get('isLoaded');
+  assert.ok(stub.calledOnce, 'isLoaded was called once');
+});
+
+test('load', function (assert) {
+  assert.expect(1);
+  let service = this.subject();
+  const stub = this.stub(esriLoader, 'bootstrap', function (callback) {
+    callback();
+  });
+  return service.load().then(() => {
+    assert.ok(stub.calledOnce, 'bootstrap was called once');
   });
 });
 
-// TODO: move the logic of tests to the esri-loader library
-test('load', function(assert) {
-  const done = assert.async();
+test('load with options', function (assert) {
   assert.expect(2);
   let service = this.subject();
-  const stub = this.stub(document.body, 'appendChild', (el) => {
-    el.onload();
-  });
-  service.load();
-  assert.ok(stub.calledOnce, 'appendChild was called once');
-  assert.equal(stub.getCall(0).args[0].src, 'https://js.arcgis.com/4.3/');
-  done();
-});
-
-test('load other version', function(assert) {
-  const done = assert.async();
-  assert.expect(2);
-  let service = this.subject();
-  const stub = this.stub(document.body, 'appendChild', (el) => {
-    el.onload();
-  });
-  service.load({
+  const options = {
     url: 'https://js.arcgis.com/3.20'
+  };
+  const stub = this.stub(esriLoader, 'bootstrap', function (callback, opts) {
+    assert.equal(opts, options);
+    callback();
   });
-  assert.ok(stub.calledOnce, 'appendChild was called once');
-  assert.equal(stub.getCall(0).args[0].src, 'https://js.arcgis.com/3.20');
-  done();
+  return service.load(options).then(() => {
+    assert.ok(stub.calledOnce, 'bootstrap was called once');
+  });
 });
 
-test('load modules', function(assert) {
-  const done = assert.async();
+test('load modules when API is loaded', function (assert) {
+  assert.expect(2);
+  let service = this.subject();
+  const moduleNames = ['esri/map', 'esri/layers/VectorTileLayer'];
+  const stub = this.stub(esriLoader, 'dojoRequire', function (modNames, callback) {
+    assert.equal(modNames, moduleNames);
+    callback();
+  });
+  // emulate loaded condition
+  this.stub(esriLoader, 'isLoaded', function () {
+    return true;
+  });
+  return service.loadModules(moduleNames).then(() => {
+    assert.ok(stub.calledOnce, 'dojoRequire was called once');
+  });
+});
+
+test('load modules when API is not loaded', function (assert) {
   assert.expect(1);
   let service = this.subject();
   const moduleNames = ['esri/map', 'esri/layers/VectorTileLayer'];
-  window.__dojoRequire = function (names, callback) {
-    assert.equal(names, moduleNames, '__dojoRequire called w/ correct args');
+  this.stub(esriLoader, 'dojoRequire', function (modNames, callback) {
     callback();
-  };
-  service.loadModules(moduleNames);
-  done();
+  });
+  // emulate not loaded condition
+  this.stub(esriLoader, 'isLoaded', function () {
+    return false;
+  });
+  return service.loadModules(moduleNames).catch(err => {
+    assert.equal(err.message, 'The ArcGIS API for JavaScript has not been loaded. You must first call esriLoader.load()');
+  });
 });

--- a/vendor/shims/esri-loader.js
+++ b/vendor/shims/esri-loader.js
@@ -1,0 +1,10 @@
+(function() {
+  /* global self, define */
+  function vendorModule() {
+    'use strict';
+
+    return { 'default': self['esriLoader'] };
+  }
+
+  define('esri-loader', [], vendorModule);
+})();


### PR DESCRIPTION

Installs esri-loader as an npm dependency and inject as script into index.html (not importing to vendor.js so that it is not subject to find and replace on "require"). This allows this addon to remove the find and replace on "__dojoRequire".

Overall removes redundant implementation and tests and some complexity from this addon, and will make it easier to stay in sync w/ the underlying library.

resolves #13 
