### PR TITLE
[DNM] Chore/map acceptance test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ matrix:
 
 before_install:
   - npm config set spin false
-  - npm install -g bower phantomjs-prebuilt
-  - bower --version
-  - phantomjs --version
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
 
 install:
   - npm install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Changed
-- added acceptance test
+- added acceptance tests
 
 ## 0.1.2
 

--- a/addon/services/esri-loader.js
+++ b/addon/services/esri-loader.js
@@ -32,9 +32,54 @@ export default Ember.Service.extend({
     // otherwise create a promise that will resolve when the JSAPI is loaded
     this._loadPromise = new Ember.RSVP.Promise((resolve, reject) => {
       esriLoader.bootstrap(err => {
+        // need to kick of run loop in case we are in test mode
+        // see: https://discuss.emberjs.com/t/guide-asynchronous-side-effects-in-testing/2905
         Ember.run(() => {
           if (err) {
-            reject(err);
+            const message = err.message || err;
+            // has esriLoader.bootstrap already been called?
+            if (message === 'The ArcGIS API for JavaScript is already loaded.') {
+              // this can happen when there is more than one instance of this service
+              // running on the page at a time, for example, in acceptance tests
+
+              // TODO: this is _much_ better handled upstream
+              // so we want to get rid of all this once this issue is resolved:
+              // https://github.com/Esri/esri-loader/issues/28
+
+              // first check if it's the same script
+              // NOTE: will haev to update this every time it's updated here:
+              // https://github.com/Esri/esri-loader/blob/master/src/esri-loader.ts#L29
+              const defaultUrl = 'https://js.arcgis.com/4.4/';
+              const url = options.url || defaultUrl;
+              const script = document.querySelector('script[data-esri-loader]');
+              if (script.src !== url) {
+                // user tried to load two different versions of the JSAPI
+                reject(err);
+              } else {
+                // check if the script has loaded yet
+                if (script.dataset.esriLoader === 'loaded' || esriLoader.isLoaded()) {
+                  // notify any watchers of isLoaded copmuted property
+                  this.notifyPropertyChange('isLoaded');
+                  // let the caller know that the API has been successfully loaded
+                  // TODO: would there be something more useful to return here?
+                  resolve({ success: true });
+                } else {
+                  // wait for the script to load and then resolve
+                  script.addEventListener('load', () => {
+                    // more fun w/ Ember.run(), tests will fail w/o this
+                    Ember.run(() => {
+                      // notify any watchers of isLoaded copmuted property
+                      this.notifyPropertyChange('isLoaded');
+                      // let the caller know that the API has been successfully loaded
+                      // TODO: would there be something more useful to return here?
+                      resolve({ success: true });
+                    });
+                  }, false);
+                }
+              }
+            } else {
+              reject(err);
+            }
           } else {
             // notify any watchers of isLoaded copmuted property
             this.notifyPropertyChange('isLoaded');
@@ -70,9 +115,7 @@ export default Ember.Service.extend({
   _loadModules (moduleNames) {
     return new Ember.RSVP.Promise(resolve => {
       esriLoader.dojoRequire(moduleNames, (...modules) => {
-        Ember.run(() => {
-          resolve(modules);
-        });
+        resolve(modules);
       });
     });
   }

--- a/addon/services/esri-loader.js
+++ b/addon/services/esri-loader.js
@@ -32,64 +32,56 @@ export default Ember.Service.extend({
     // otherwise create a promise that will resolve when the JSAPI is loaded
     this._loadPromise = new Ember.RSVP.Promise((resolve, reject) => {
       esriLoader.bootstrap(err => {
-        // need to kick of run loop in case we are in test mode
-        // see: https://discuss.emberjs.com/t/guide-asynchronous-side-effects-in-testing/2905
-        Ember.run(() => {
-          if (err) {
-            const message = err.message || err;
-            // has esriLoader.bootstrap already been called?
-            if (message === 'The ArcGIS API for JavaScript is already loaded.') {
-              // this can happen when there is more than one instance of this service
-              // running on the page at a time, for example, in acceptance tests
+        if (err) {
+          const message = err.message || err;
+          // has esriLoader.bootstrap already been called?
+          if (message === 'The ArcGIS API for JavaScript is already loaded.') {
+            // this can happen when there is more than one instance of this service
+            // running on the page at a time, for example, in acceptance tests
 
-              // TODO: this is _much_ better handled upstream
-              // so we want to get rid of all this once this issue is resolved:
-              // https://github.com/Esri/esri-loader/issues/28
+            // TODO: this is _much_ better handled upstream
+            // so we want to get rid of all this once this issue is resolved:
+            // https://github.com/Esri/esri-loader/issues/28
 
-              // first check if it's the same script
-              // NOTE: will haev to update this every time it's updated here:
-              // https://github.com/Esri/esri-loader/blob/master/src/esri-loader.ts#L29
-              const defaultUrl = 'https://js.arcgis.com/4.4/';
-              const url = options.url || defaultUrl;
-              const script = document.querySelector('script[data-esri-loader]');
-              if (script.src !== url) {
-                // user tried to load two different versions of the JSAPI
-                reject(err);
-              } else {
-                // check if the script has loaded yet
-                if (script.dataset.esriLoader === 'loaded' || esriLoader.isLoaded()) {
-                  // notify any watchers of isLoaded copmuted property
-                  this.notifyPropertyChange('isLoaded');
-                  // let the caller know that the API has been successfully loaded
-                  // TODO: would there be something more useful to return here?
-                  resolve({ success: true });
-                } else {
-                  // wait for the script to load and then resolve
-                  script.addEventListener('load', () => {
-                    // TODO: remove this event listener
-                    // more fun w/ Ember.run(), tests will fail w/o this
-                    Ember.run(() => {
-                      // notify any watchers of isLoaded copmuted property
-                      this.notifyPropertyChange('isLoaded');
-                      // let the caller know that the API has been successfully loaded
-                      // TODO: would there be something more useful to return here?
-                      resolve({ success: true });
-                    });
-                  }, false);
-                }
-              }
-            } else {
+            // first check if it's the same script
+            // NOTE: will haev to update this every time it's updated here:
+            // https://github.com/Esri/esri-loader/blob/master/src/esri-loader.ts#L29
+            const defaultUrl = 'https://js.arcgis.com/4.4/';
+            const url = options.url || defaultUrl;
+            const script = document.querySelector('script[data-esri-loader]');
+            if (script.src !== url) {
+              // user tried to load two different JSAPI scripts
               reject(err);
+            } else {
+              // check if the script has loaded yet
+              if (script.dataset.esriLoader === 'loaded' || esriLoader.isLoaded()) {
+                resolve();
+              } else {
+                // wait for the script to load and then resolve
+                script.addEventListener('load', () => {
+                  // TODO: remove this event listener
+                  resolve();
+                }, false);
+              }
             }
           } else {
-            // notify any watchers of isLoaded copmuted property
-            this.notifyPropertyChange('isLoaded');
-            // let the caller know that the API has been successfully loaded
-            // TODO: would there be something more useful to return here?
-            resolve({ success: true });
+            // not an error we can handle
+            reject(err);
           }
-        });
+        } else {
+          // no err
+          resolve();
+        }
       }, options);
+    })
+    .then(() => {
+      // update the isLoaded computed property
+      this.notifyPropertyChange('isLoaded');
+      // let the caller know that the API has been successfully loaded
+      // TODO: would there be something more useful to return here?
+      // bootstrap returns dojoRequire,
+      // but we want consumers to use loadModules instead
+      return { success: true };
     });
     return this._loadPromise;
   },

--- a/addon/services/esri-loader.js
+++ b/addon/services/esri-loader.js
@@ -66,6 +66,7 @@ export default Ember.Service.extend({
                 } else {
                   // wait for the script to load and then resolve
                   script.addEventListener('load', () => {
+                    // TODO: remove this event listener
                     // more fun w/ Ember.run(), tests will fail w/o this
                     Ember.run(() => {
                       // notify any watchers of isLoaded copmuted property

--- a/addon/services/esri-loader.js
+++ b/addon/services/esri-loader.js
@@ -70,7 +70,9 @@ export default Ember.Service.extend({
   _loadModules (moduleNames) {
     return new Ember.RSVP.Promise(resolve => {
       esriLoader.dojoRequire(moduleNames, (...modules) => {
-        resolve(modules);
+        Ember.run(() => {
+          resolve(modules);
+        });
       });
     });
   }

--- a/testem.js
+++ b/testem.js
@@ -4,10 +4,9 @@ module.exports = {
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
   "launch_in_ci": [
-    "PhantomJS"
+    "FireFox"
   ],
   "launch_in_dev": [
-    "PhantomJS",
     "Chrome"
   ]
 };

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -21,7 +21,8 @@
     "andThen",
     "currentURL",
     "currentPath",
-    "currentRouteName"
+    "currentRouteName",
+    "waitForElement"
   ],
   "node": false,
   "browser": false,

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -3,11 +3,6 @@ import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 
 moduleForAcceptance('Acceptance | index');
 
-// NOTE: can't run more than one acceptance test w/ the way that
-// we currently preload the JSAPI in the application route's renderTemplate() hook
-// b/c it gets called twice and throws "The ArcGIS API for JavaScript is already loaded."
-// and ember in it's infinite wisdom decides to fail the test even though the route does .catch() the error
-// TODO: don't skip this test once we resolve the above issue
 test('visiting /', function(assert) {
   visit('/');
 

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -8,6 +8,7 @@ test('visiting /', function(assert) {
 
   andThen(function() {
     assert.equal(currentURL(), '/');
+
     assert.equal(find('p strong span').text().substr(0, 4), 'Load', 'status should be either Loading... or Loaded');
   });
 });

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -1,9 +1,14 @@
-import { test } from 'qunit';
+import { skip } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 
 moduleForAcceptance('Acceptance | index');
 
-test('visiting /', function(assert) {
+// NOTE: can't run more than one acceptance test w/ the way that
+// we currently preload the JSAPI in the application route's renderTemplate() hook
+// b/c it gets called twice and throws "The ArcGIS API for JavaScript is already loaded."
+// and ember in it's infinite wisdom decides to fail the test even though the route does .catch() the error
+// TODO: don't skip this test once we resolve the above issue
+skip('visiting /', function(assert) {
   visit('/');
 
   andThen(function() {

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -8,7 +8,6 @@ test('visiting /', function(assert) {
 
   andThen(function() {
     assert.equal(currentURL(), '/');
-
     assert.equal(find('p strong span').text().substr(0, 4), 'Load', 'status should be either Loading... or Loaded');
   });
 });

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -1,4 +1,4 @@
-import { skip } from 'qunit';
+import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 
 moduleForAcceptance('Acceptance | index');
@@ -8,7 +8,7 @@ moduleForAcceptance('Acceptance | index');
 // b/c it gets called twice and throws "The ArcGIS API for JavaScript is already loaded."
 // and ember in it's infinite wisdom decides to fail the test even though the route does .catch() the error
 // TODO: don't skip this test once we resolve the above issue
-skip('visiting /', function(assert) {
+test('visiting /', function(assert) {
   visit('/');
 
   andThen(function() {

--- a/tests/acceptance/map-test.js
+++ b/tests/acceptance/map-test.js
@@ -8,8 +8,11 @@ test('visiting /map', function(assert) {
 
   andThen(function() {
     assert.equal(currentURL(), '/map');
-    // TODO: write an async helper to wait for the map to load
-    // and then validate the map DOM
-    // assert.equal(find('.esri-view-root').length, 1);
+    // wait for the map to load
+    waitForElement('.esri-view-root');
+    andThen(function() {
+      // validate the map DOM
+      assert.equal(find('.esri-view-root').css('height'), '400px');
+    });
   });
 });

--- a/tests/acceptance/map-test.js
+++ b/tests/acceptance/map-test.js
@@ -1,0 +1,15 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | map');
+
+test('visiting /map', function(assert) {
+  visit('/map');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/map');
+    // TODO: write an async helper to wait for the map to load
+    // and then validate the map DOM
+    // assert.equal(find('.esri-view-root').length, 1);
+  });
+});

--- a/tests/dummy/app/components/scene-view.js
+++ b/tests/dummy/app/components/scene-view.js
@@ -13,6 +13,9 @@ export default Ember.Component.extend({
     this._super(...arguments);
     // load the esri modules
     this.get('esriLoader').loadModules(['esri/views/SceneView', 'esri/Map']).then(modules => {
+      if (this.get('isDestroyed') || this.get('isDestroying')) {
+        return;
+      }
       const [SceneView, Map] = modules;
       // create a new scene view
       this._view = new SceneView({

--- a/tests/dummy/app/components/web-map.js
+++ b/tests/dummy/app/components/web-map.js
@@ -9,6 +9,9 @@ export default Ember.Component.extend({
     this._super(...arguments);
     // load the map modules
     this.get('esriLoader').loadModules(['esri/views/MapView', 'esri/WebMap']).then(modules => {
+      if (this.get('isDestroyed') || this.get('isDestroying')) {
+        return;
+      }
       const [MapView, WebMap] = modules;
       // load the webmap from a portal item
       const webmap = new WebMap({

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
+import './wait-for-element';
 
 export default function startApp(attrs) {
   let application;

--- a/tests/helpers/wait-for-element.js
+++ b/tests/helpers/wait-for-element.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+
+export default Ember.Test.registerAsyncHelper('waitForElement', function(app, selector, context, interval=300) {
+  return new Ember.Test.promise(function (resolve) {
+    // inform the test framework that there is an async operation in progress,
+    // so it shouldn't consider the test complete
+    Ember.Test.adapter.asyncStart();
+    let intervalId = window.setInterval(function () {
+      let $el = find(selector, context);
+      if ($el.length > 0) {
+        Ember.run (function () {
+          // stop this loop and resolve the promise
+          window.clearInterval(intervalId);
+          resolve();
+        });
+        // inform the test framework that this async operation is complete
+        Ember.Test.adapter.asyncEnd();
+      }
+    }, interval);
+  });
+});


### PR DESCRIPTION
~~This PR suffers from the same problems in #27 - we still can't run more than a single acceptance test.~~

In addition, by trying to actually test the map, we now get the following error every time in PhantomJS (but not in Chrome):

```
Global error: Script error. at , line 0

JSHint | unit/services/esri-loader-test.js: global failure
    ✘ Script error.
        :0
Script error. at , line 0
```

NOTE: that error was happening in ad5c133 - when the acceptance test didn't even try to wait for and inspect the map. In other words, the error occurs simply by _loading the JSAPI modules_, not even using them. Which sucks, b/c it was such a royal PIA to write a test helper to wait for the map to load.

I'm so f'ing over Ember acceptance tests and the JSAPI.

