### PR TITLE
Fixing overlapping regex for #31

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,11 +75,11 @@ module.exports = {
         new RegExp(path.parse(outputPaths.testSupport.js.testSupport).name + '(.*js)')
       ],
       patterns: [{
-        match: /([^A-Za-z0-9_#]|^|["])define(\W|["]|$)/g,
-        replacement: '$1efineday$2'
+        match: /([^A-Za-z0-9_#]|^|["])define(?=\W|["]|$)/g,
+        replacement: '$1efineday'
       }, {
-        match: /(\W|^|["])require(\W|["]|$)/g,
-        replacement: '$1equireray$2'
+        match: /(\W|^|["])require(?=\W|["]|$)/g,
+        replacement: '$1equireray'
       }]
     };
     var dataTree = stringReplace(tree, data);


### PR DESCRIPTION
Overlapping regex matches were causing define:define and require:require strings to not be replaced correctly.  Added a look ahead to fix this issue.