### PR TITLE
loadModules() can now lazy load the ArcGIS API; default to v4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+- `loadModules()` can now lazy load the ArcGIS API
+
+### Changed
+- bumped ersi-loader to 1.5.0 for the promise-based API and defaulting to the latest JSAPI (v.4.5)
+
 ## 0.1.4
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -29,57 +29,9 @@ Before you can use the ArcGIS API in your app, you'll need to load the styles, f
 @import url('https://js.arcgis.com/3.20/esri/css/esri.css');
 ```
 
-### Pre-loading the ArcGIS API for JavaScript
-
-If you have good reason to believe that the user is going to transition to a map route, you may want to start pre-loading the ArcGIS API as soon as possible w/o blocking template rendering. You can add the following to the application route:
-
-```js
-// app/routes/application.js
-import Ember from 'ember';
-
-export default Ember.Route.extend({
-  esriLoader: Ember.inject.service('esri-loader'),
-
-  renderTemplate: function () {
-    // render the template as normal
-    this._super(...arguments);
-    // then preload the JSAPI
-    // NOTE: to use the latest 4.x release don't pass any arguments to load()
-    this.get('esriLoader').load().catch(err => {
-      // do something with the error
-    });
-  }
-});
-```
-
-### Lazy Loading the ArcGIS API for JavaScript
-
-Alternatively you can lazy load the ArcGIS API for JavaScript the first time a user goes to the map's route. One way would be to add the following to the route's controller:
-
-```js
-// app/controllers/map.js
-import Ember from 'ember';
-
-export default Ember.Controller.extend({
-  esriLoader: Ember.inject.service('esri-loader'),
-
-  // this will be called only the first time the route is loaded
-  init () {
-    this._super(...arguments);
-    // lazy load the JSAPI
-    const esriLoader = this.get('esriLoader');
-    // NOTE: to use a version other than the latest  4.x release
-    // pass the url in the options argument to load()
-    esriLoader.load({ url: 'https://js.arcgis.com/3.20compact' }).catch(err => {
-      // do something with the error
-    });
-  }
-});
-```
-
 ### Loading Modules from the ArcGIS API for JavaScript
 
-Once you've loaded the API (typically in a route or controller), you can then load modules. Here's an example of how you could load and use the 3.x `Map` and `VectorTileLayer` classes in a component to create a map:
+Here's an example of how you could load and use the 3.x `Map` and `VectorTileLayer` classes in a component to create a map:
 
 ```js
 // app/components/esri-map.js
@@ -93,8 +45,13 @@ export default Ember.Component.extend({
   // once we have a DOM node to attach the map to...
   didInsertElement () {
     this._super(...arguments);
+    // options are only needed b/c we're not using the latest 4.x version of the API
+    const options = {
+      url: 'https://js.arcgis.com/3.20compact'
+    };
     // load the map modules
-    this.get('esriLoader').loadModules(['esri/map', 'esri/layers/VectorTileLayer']).then(modules => {
+    this.get('esriLoader').loadModules(['esri/map', 'esri/layers/VectorTileLayer'], options)
+    .then(modules => {
       const [Map, VectorTileLayer] = modules;
       // create a map at the DOM node
       this._map = new Map(this.elementId, {
@@ -116,6 +73,36 @@ export default Ember.Component.extend({
   }
 });
 ```
+
+#### Lazy Loading the ArcGIS API for JavaScript
+
+The above code will lazy load the ArcGIS API for JavaScript the first time `loadModules()` is called. This means users of your application won't need to wait for the ArcGIS API to download until it is need.
+
+### Pre-loading the ArcGIS API for JavaScript
+
+Alternatively, if you have good reason to believe that the user is going to transition to a map route, you may want to start pre-loading the ArcGIS API as soon as possible w/o blocking template rendering. You can add the following to the application route:
+
+```js
+// app/routes/application.js
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  esriLoader: Ember.inject.service('esri-loader'),
+
+  renderTemplate: function () {
+    // render the template as normal
+    this._super(...arguments);
+    // then preload the JSAPI
+    // NOTE: to use the latest 4.x release don't pass any arguments to loadScript()
+    this.get('esriLoader').loadScript()
+    .catch(err => {
+      // do something with the error
+    });
+  }
+});
+```
+
+Now you can use `loadModules()` in components to [create maps](https://github.com/Esri/ember-esri-loader/blob/master/tests/dummy/app/components/web-map.js) or [3D scenes](https://github.com/Esri/ember-esri-loader/blob/master/tests/dummy/app/components/scene-view.js). Also, if you need to, you can [use `isLoaded()` anywhere in your application to find out whether or not the ArcGIS API has finished loading](https://github.com/Esri/ember-esri-loader/blob/master/tests/dummy/app/controllers/application.js).
 
 ## How It Works
 

--- a/addon/services/esri-loader.js
+++ b/addon/services/esri-loader.js
@@ -15,6 +15,12 @@ import esriLoader from 'esri-loader';
 
 export default Ember.Service.extend({
 
+  init () {
+    this._super(...arguments);
+    // have esriLoader use Ember's RSVP promise
+    esriLoader.utils.Promise = Ember.RSVP.Promise;
+  },
+
   // emulate computed property isLoaded to indicate that the JSAPI been loaded
   unknownProperty (key) {
     if (key === 'isLoaded') {
@@ -22,94 +28,31 @@ export default Ember.Service.extend({
     }
   },
 
+  loadScript (options) {
+    return esriLoader.loadScript(options)
+    .then(script => {
+      // have to wrap this async side effect in Ember.run() so tests don't fail
+      // may be able to remove this once we can have esriLoader use RSVP.Promise
+      Ember.run(() => {
+        // update the isLoaded computed property
+        this.notifyPropertyChange('isLoaded');
+        return script;
+      });
+    });
+  },
+
   // inject a script tag pointing to the JSAPI in the page
   // and return a promise once it's loaded
   load (options = {}) {
-    // if already loading or loaded, return the existing promise
-    if (this._loadPromise) {
-      return this._loadPromise;
-    }
-    // otherwise create a promise that will resolve when the JSAPI is loaded
-    this._loadPromise = new Ember.RSVP.Promise((resolve, reject) => {
-      esriLoader.bootstrap(err => {
-        if (err) {
-          const message = err.message || err;
-          // has esriLoader.bootstrap already been called?
-          if (message === 'The ArcGIS API for JavaScript is already loaded.') {
-            // this can happen when there is more than one instance of this service
-            // running on the page at a time, for example, in acceptance tests
-
-            // TODO: this is _much_ better handled upstream
-            // so we want to get rid of all this once this issue is resolved:
-            // https://github.com/Esri/esri-loader/issues/28
-
-            // first check if it's the same script
-            // NOTE: will haev to update this every time it's updated here:
-            // https://github.com/Esri/esri-loader/blob/master/src/esri-loader.ts#L29
-            const defaultUrl = 'https://js.arcgis.com/4.4/';
-            const url = options.url || defaultUrl;
-            const script = document.querySelector('script[data-esri-loader]');
-            if (script.src !== url) {
-              // user tried to load two different JSAPI scripts
-              reject(err);
-            } else {
-              // check if the script has loaded yet
-              if (script.dataset.esriLoader === 'loaded' || esriLoader.isLoaded()) {
-                resolve();
-              } else {
-                // wait for the script to load and then resolve
-                script.addEventListener('load', () => {
-                  // TODO: remove this event listener
-                  resolve();
-                }, false);
-              }
-            }
-          } else {
-            // not an error we can handle
-            reject(err);
-          }
-        } else {
-          // no err
-          resolve();
-        }
-      }, options);
-    })
-    .then(() => {
-      // update the isLoaded computed property
-      this.notifyPropertyChange('isLoaded');
-      // let the caller know that the API has been successfully loaded
-      // TODO: would there be something more useful to return here?
-      // bootstrap returns dojoRequire,
-      // but we want consumers to use loadModules instead
-      return { success: true };
+    Ember.deprecate('esriLoader.load() will be removed at the next breaking version. Use esriLoader.loadScript() instead.', false, {
+      id: 'ember-esri-loader.load',
+      until: '10.0.0'
     });
-    return this._loadPromise;
+    return this.loadScript(options);
   },
 
   // require the modules and return a pomise that reolves them as an array
-  loadModules (moduleNames) {
-    // TODO: validate that moduleNames is an array w/ at least one string?
-    // or just continue to let dojo throw "Cannot read property 'has' of undefined"?
-    // TODO: we can probably delegate some or all of this logic to esriLoader.dojoRequire
-    if (this.get('isLoaded')) {
-      return this._loadModules(moduleNames);
-    } else {
-      if (this._loadPromise) {
-        // load modules once finished loadng the JSAPI
-        return this._loadPromise.then(Ember.run.bind(this, this._loadModules, moduleNames));
-      } else {
-        // not loaded or loading
-        return Ember.RSVP.reject(new Error('The ArcGIS API for JavaScript has not been loaded. You must first call esriLoader.load()'));
-      }
-    }
-  },
-
-  // wrap esriLoader's dojoRequire in a promise
-  _loadModules (moduleNames) {
-    return new Ember.RSVP.Promise(resolve => {
-      esriLoader.dojoRequire(moduleNames, (...modules) => {
-        resolve(modules);
-      });
-    });
+  loadModules (moduleNames, options) {
+    return esriLoader.loadModules(moduleNames, options);
   }
 });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-string-replace": "^0.1.2",
     "ember-cli-babel": "^5.1.7",
-    "esri-loader": "^1.1.0"
+    "esri-loader": "^1.5.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -7,7 +7,8 @@ export default Ember.Route.extend({
     // render the template as normal
     this._super(...arguments);
     // then preload the latest (4.x) version of the JSAPI
-    this.get('esriLoader').load().catch(err => {
+    this.get('esriLoader').loadScript()
+    .catch(err => {
       // TODO: better way of showing error
       window.alert(err.message || err);
     });

--- a/tests/unit/services/esri-loader-test.js
+++ b/tests/unit/services/esri-loader-test.js
@@ -1,6 +1,7 @@
 import { moduleFor } from 'ember-qunit';
 import test from 'ember-sinon-qunit/test-support/test';
 import esriLoader from 'esri-loader';
+import Ember from 'ember';
 
 moduleFor('service:esri-loader', 'Unit | Service | esri loader', {
   // Specify the other units that are required for this test.
@@ -14,61 +15,60 @@ test('isLoaded', function (assert) {
   assert.ok(stub.calledOnce, 'isLoaded was called once');
 });
 
-test('load', function (assert) {
-  assert.expect(1);
+test('loadScript', function (assert) {
+  assert.expect(2);
   let service = this.subject();
-  const stub = this.stub(esriLoader, 'bootstrap', function (callback) {
-    callback();
+  const stub = this.stub(esriLoader, 'loadScript', function (options) {
+    assert.notOk(options, 'should not pass options');
+    return Ember.RSVP.resolve();
   });
-  return service.load().then(() => {
-    assert.ok(stub.calledOnce, 'bootstrap was called once');
+  return service.loadScript().then(() => {
+    assert.ok(stub.calledOnce, 'loadScript was called once');
   });
 });
 
-test('load with options', function (assert) {
+test('loadScript with options', function (assert) {
   assert.expect(2);
   let service = this.subject();
   const options = {
     url: 'https://js.arcgis.com/3.20'
   };
-  const stub = this.stub(esriLoader, 'bootstrap', function (callback, opts) {
-    assert.equal(opts, options);
-    callback();
+  const stub = this.stub(esriLoader, 'loadScript', function (opts) {
+    assert.equal(opts, options, 'should have passed in options');
+    return Ember.RSVP.resolve();
   });
-  return service.load(options).then(() => {
+  return service.loadScript(options).then(() => {
     assert.ok(stub.calledOnce, 'bootstrap was called once');
   });
 });
 
-test('load modules when API is loaded', function (assert) {
-  assert.expect(2);
+test('loadModules', function (assert) {
+  assert.expect(3);
   let service = this.subject();
   const moduleNames = ['esri/map', 'esri/layers/VectorTileLayer'];
-  const stub = this.stub(esriLoader, 'dojoRequire', function (modNames, callback) {
-    assert.equal(modNames, moduleNames);
-    callback();
-  });
-  // emulate loaded condition
-  this.stub(esriLoader, 'isLoaded', function () {
-    return true;
+  const stub = this.stub(esriLoader, 'loadModules', function (modNames, opts) {
+    assert.equal(modNames, moduleNames, 'should pass same modules names');
+    assert.notOk(opts, 'should not pass options');
+    return Ember.RSVP.resolve();
   });
   return service.loadModules(moduleNames).then(() => {
-    assert.ok(stub.calledOnce, 'dojoRequire was called once');
+    assert.ok(stub.calledOnce, 'loadModules was called once');
   });
 });
 
-test('load modules when API is not loaded', function (assert) {
-  assert.expect(1);
+test('loadModules with options', function (assert) {
+  assert.expect(3);
   let service = this.subject();
   const moduleNames = ['esri/map', 'esri/layers/VectorTileLayer'];
-  this.stub(esriLoader, 'dojoRequire', function (modNames, callback) {
-    callback();
+  const options = {
+    url: 'https://js.arcgis.com/3.20'
+  };
+  const stub = this.stub(esriLoader, 'loadModules', function (modNames, opts) {
+    assert.equal(modNames, moduleNames, 'should pass same modules names');
+    assert.equal(opts, options, 'should have passed in options');
+    return Ember.RSVP.resolve();
   });
-  // emulate not loaded condition
-  this.stub(esriLoader, 'isLoaded', function () {
-    return false;
-  });
-  return service.loadModules(moduleNames).catch(err => {
-    assert.equal(err.message, 'The ArcGIS API for JavaScript has not been loaded. You must first call esriLoader.load()');
+  return service.loadModules(moduleNames, options).then(() => {
+    assert.ok(stub.calledOnce, 'loadModules was called once');
   });
 });


### PR DESCRIPTION
bumped ersi-loader to 1.5.0 for the promise-based API and defaulting to the latest JSAPI (v.4.5)
configure esri-loader to use Ember.RSVP.Promise