### PR TITLE
updated regex so it works w/ ember-bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+- updated regex so it works w/ ember-bootstrap [#48](https://github.com/Esri/ember-esri-loader/issues/48)
+
 ### Changed
 - added Examples section to README
 

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ module.exports = {
         new RegExp(path.parse(outputPaths.testSupport.js.testSupport).name + '(.*js)')
       ],
       patterns: [{
-        match: /([^A-Za-z0-9_#]|^|["])define(?=\W|["]|$)/g,
+        match: /([^A-Za-z0-9_#']|^|["])define(?=\W|["]|$)/g,
         replacement: '$1efineday'
       }, {
         match: /(\W|^|["])require(?=\W|["]|$)/g,


### PR DESCRIPTION
resolves #48
udpated 'efineday' regex so it doesn't catch `Object[('define' + 'Property')]`