### PR TITLE
Apply transforms to lazy engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# Unreleased
+### Added
+- during build, we check for lazy engines, and if present, apply the transforms to those files as well.
+
 ## 2.4.0
 
 ### Added


### PR DESCRIPTION
During the build process, inspect the app's addons, and search for any lazy-engine addons. If found, add the js files for the engine to the list of files to be transformed.

resolves #6 