### PR TITLE
Use ^ instead of ~ for the esri-loader dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-string-replace": "^0.1.2",
     "ember-cli-babel": "^6.16.0",
-    "esri-loader": "~2.5.0"
+    "esri-loader": "^2.0.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3383,9 +3383,10 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
-esri-loader@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/esri-loader/-/esri-loader-2.5.0.tgz#2f3c366a99672ac5f1c89aa62038b3ec36bbb4f8"
+esri-loader@^2.0.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/esri-loader/-/esri-loader-2.6.0.tgz#fc44cc8888161937e48346c4eb069433686fddc3"
+  integrity sha512-XY9ItlT6+5UVy0s5AS89YRVRKmMm7DqOD3f/jp/8Xxoapp6ffw79RbUnWFuM8qjYb1EewkjSwFMS+2ZAdkXzMA==
 
 estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.2.0"


### PR DESCRIPTION
This will let package managers automatically install the latest (Semver compatible) version without having to bump the version manually.

"Fixes" https://github.com/Esri/ember-esri-loader/issues/64