### PR TITLE
Lock to esri-loader 2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-string-replace": "^0.1.2",
     "ember-cli-babel": "^6.16.0",
-    "esri-loader": "^2.0.0"
+    "esri-loader": "~2.6.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-string-replace": "^0.1.2",
     "ember-cli-babel": "^6.16.0",
-    "esri-loader": "~2.6.0"
+    "esri-loader": "~2.5.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",


### PR DESCRIPTION
This reverts the ^ notation commit. That commit had the unintended side effect that the map css version was not always in sync with the loaded ArcGIS api version when not specifying a url in the options.

It also hard locks to the latest version of esri-loader.