### PR TITLE
always inject esri-loader script in head so it is before vendor.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Fixed
+- always inject esri-loader script in head so it is before vendor.js
 
 ## 2.8.0
 ### Added

--- a/index.js
+++ b/index.js
@@ -44,10 +44,8 @@ module.exports = {
   // inject esri-loader script tag instead of importing into vendor.js
   // so that it is not subject to the find and replace below
   contentFor (type, config) {
-    var env = config.environment;
-    var isTest = config.environment === 'test';
-    if ((type === 'body-footer' && !isTest) || (type === 'test-head-footer' && isTest)) {
-      var fileName = env === 'production' ? 'esri-loader.min.js' : 'esri-loader.js';
+    if (type === 'head-footer') {
+      var fileName = config.environment === 'production' ? 'esri-loader.min.js' : 'esri-loader.js';
       return '<script src="' + (config.rootURL || '') + 'assets/' + fileName + '"></script>';
     }
   },


### PR DESCRIPTION
Previously we would append it to the `<body>` unless the environment was test, in which case we appended to the end of the head to ensure that esri-loader was injected before the test code.

However, this has a few issues
- some apps don't use `config.environment === 'test'` when running tests
- in non-test environments, the esri-loader script would be loaded _after_ vendor.js

In theory the latter could cause an issue if someone tried to use esri-loader during app startup. So far that has never come up, but it is theoretically possible.

Either way, it's best if we are sure the esri-loader script is loaded _before_ vendor.js (b/c that has the shim).

The downside of the solution in this PR is that it _always_ makes blocking request for the esri-loader JS, _but_ the script is small. A better solution would be to specify that it should be injected immediately about vendor.js, but I don't know how to do that.
